### PR TITLE
Check that CURRENT_VERSION is not empty

### DIFF
--- a/Duelyst-Updater
+++ b/Duelyst-Updater
@@ -44,6 +44,11 @@ update_duelyst () {
 CURRENT_VERSION=$(curl https://updates.counterplay.co/ 2>/dev/null | grep -v staging | grep zip |\
                   grep -o http://downloads.counterplay.co/duelyst/v[0-9\.]* | head -n 1 | tail -c +42)
 
+if [ -z $CURRENT_VERSION ]; then
+	echo "Could not determine current version; no internet?";
+	exit 1
+fi
+
 cd "`dirname "$0"`"
 
 if [ -f local_version ]; then


### PR DESCRIPTION
Running the launcher with no internet connection resulted in the local version being deleted and the directory left in an invalid state. This adds a check to prevent that from happening.